### PR TITLE
Grant plan action the write permissions for diffs

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -13,7 +13,7 @@ jobs:
 
     permissions:
       pull-requests: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Without the write permission the diffs were invalid.

Source:
https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository