### PR TITLE
fix: remove playground2

### DIFF
--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -77,14 +77,4 @@ repositories = {
     members    = []
   }
 
-
-  "playground2" = {
-    description = "Tests"
-
-    admins = [
-      "cunla",
-    ]
-    committers = []
-    members    = []
-  }
 }

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -64,11 +64,11 @@ repositories = {
   }
 
   "django-fsm-2" = {
-    description          = "Django friendly finite state machine support"
-    homepage_url         = "https://github.com/django-commons/django-fsm-2"
-    allow_merge_commit   = false
-    allow_rebase_merge   = true
-    has_projects         = false
+    description        = "Django friendly finite state machine support"
+    homepage_url       = "https://github.com/django-commons/django-fsm-2"
+    allow_merge_commit = false
+    allow_rebase_merge = true
+    has_projects       = false
 
     admins = [
       "pfouque",

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -69,7 +69,6 @@ repositories = {
     allow_merge_commit   = false
     allow_rebase_merge   = true
     has_projects         = false
-    merge_commit_message = "BLANK"
 
     admins = [
       "pfouque",

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -69,6 +69,8 @@ repositories = {
     allow_merge_commit = false
     allow_rebase_merge = true
     has_projects       = false
+    merge_commit_message = "BLANK"
+
     admins = [
       "pfouque",
       "natim",

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -64,11 +64,11 @@ repositories = {
   }
 
   "django-fsm-2" = {
-    description        = "Django friendly finite state machine support"
-    homepage_url       = "https://github.com/django-commons/django-fsm-2"
-    allow_merge_commit = false
-    allow_rebase_merge = true
-    has_projects       = false
+    description          = "Django friendly finite state machine support"
+    homepage_url         = "https://github.com/django-commons/django-fsm-2"
+    allow_merge_commit   = false
+    allow_rebase_merge   = true
+    has_projects         = false
     merge_commit_message = "BLANK"
 
     admins = [

--- a/terraform/resources-repos.tf
+++ b/terraform/resources-repos.tf
@@ -15,12 +15,12 @@ resource "github_repository" "this" {
   homepage_url                = each.value.homepage_url
   allow_auto_merge            = each.value.allow_auto_merge
   allow_merge_commit          = each.value.allow_merge_commit
-  merge_commit_title          = each.value.merge_commit_title
-  merge_commit_message        = each.value.merge_commit_message
+  merge_commit_title          = each.value.allow_merge_commit ? each.value.merge_commit_title : null
+  merge_commit_message        = each.value.allow_merge_commit ? each.value.merge_commit_message : null
   allow_rebase_merge          = each.value.allow_rebase_merge
   allow_squash_merge          = each.value.allow_squash_merge
-  squash_merge_commit_title   = each.value.squash_merge_commit_title
-  squash_merge_commit_message = each.value.squash_merge_commit_message
+  squash_merge_commit_title   = each.value.allow_squash_merge ? each.value.squash_merge_commit_title : null
+  squash_merge_commit_message = each.value.allow_squash_merge ? each.value.squash_merge_commit_message : null
   allow_update_branch         = each.value.allow_update_branch
   archive_on_destroy          = true
   delete_branch_on_merge      = each.value.delete_branch_on_merge

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,8 +46,8 @@ variable "repositories" {
     members = optional(set(string), []) # Members of the repository team. Have triage permissions
 
     # The following are valid combinations for the merge commit title and message: PR_TITLE and PR_BODY, PR_TITLE and BLANK, MERGE_MESAGE and PR_TITLE. (invalid_merge_commit_setting_combo)}]
-    merge_commit_title          = optional(string, "PR_TITLE")
-    merge_commit_message        = optional(string, "PR_BODY")
+    merge_commit_title          = optional(string, "MERGE_MESSAGE")
+    merge_commit_message        = optional(string, "PR_TITLE")
     squash_merge_commit_title   = optional(string, "PR_TITLE")
     squash_merge_commit_message = optional(string, "PR_BODY")
   }))

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,10 +46,10 @@ variable "repositories" {
     members = optional(set(string), []) # Members of the repository team. Have triage permissions
 
     # The following are valid combinations for the merge commit title and message: PR_TITLE and PR_BODY, PR_TITLE and BLANK, MERGE_MESAGE and PR_TITLE. (invalid_merge_commit_setting_combo)}]
-    merge_commit_title          = optional(string, "MERGE_MESSAGE")
-    merge_commit_message        = optional(string, "PR_TITLE")
-    squash_merge_commit_title   = optional(string, "PR_TITLE")
-    squash_merge_commit_message = optional(string, "PR_BODY")
+    merge_commit_title          = optional(string, null)
+    merge_commit_message        = optional(string, null)
+    squash_merge_commit_title   = optional(string, null)
+    squash_merge_commit_message = optional(string, null)
   }))
 }
 


### PR DESCRIPTION
Additionally, some changes to terraform action so it will stop spamming with changing merge-commits
- `merge_commit_title` and `merge_commit_message` are set only if `allow_merge_commit`
- `squash_merge_commit_title` and `squash_merge_commit_message` are set only if `allow_squash_merge`