### PR TITLE
Add follow-up step to add member playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Django Commons packages.
 5. Create a pull-request to `main` branch. This will trigger terraform to plan the changes in the organization to be
    executed. Review the changes and make sure they align with the request.
 6. Merge the pull request. This will trigger terraform to apply the changes in the organization.
+7. Comment on the issue, thanking the person for joining and reminding them that it helps the
+   organization's reach if they set their membership visibility as public.
+
+   > Thank you <NAME> for joining! You'll get an invite email from GitHub. You'll have one
+   > week to accept that. If you don't mind, after accepting, can you set your
+   > [organization membership as public](https://github.com/orgs/django-commons/people)?
+   > This helps Django Commons grow. 
 
 ## Repository Team Change Playbook
 


### PR DESCRIPTION
We noticed the memberships are created as private originally. Since we already need to acknowledge and thank the person for joining, let's call it out there until we find a better process.

This is a follow-up to the [django-commons-admins google group discussion](https://groups.google.com/d/msgid/django-commons-admin/CAEgUdVvjWKP%2BQiB4Y8i%2Bb1owUM49%2BcNXjzfbJnxAAK8Sh11vGQ%40mail.gmail.com)